### PR TITLE
fix: Add frontend build step to Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
   "builds": [
     {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
       "src": "api/cmd/vercel/main.go",
       "use": "@vercel/go"
     }


### PR DESCRIPTION
Updated vercel.json to include a build step for the frontend using '@vercel/static-build'. This ensures that both the frontend and backend are built during deployment, resolving the issue where only the backend was being built.